### PR TITLE
Elixir support

### DIFF
--- a/packages/tailwindcss-language-service/src/completionProvider.ts
+++ b/packages/tailwindcss-language-service/src/completionProvider.ts
@@ -36,6 +36,7 @@ import {
   addPixelEquivalentsToMediaQuery,
   addPixelEquivalentsToValue,
 } from './util/pixelEquivalents'
+import { isExContext, isExDoc } from './util/ex'
 
 let isUtil = (className) =>
   Array.isArray(className.__info)
@@ -624,7 +625,7 @@ async function provideClassNameCompletions(
     return provideAtApplyCompletions(state, document, position, context)
   }
 
-  if (isHtmlContext(state, document, position) || isJsxContext(state, document, position)) {
+  if (isHtmlContext(state, document, position) || isJsxContext(state, document, position) || isExContext(state, document, position)) {
     return provideClassAttributeCompletions(state, document, position, context)
   }
 
@@ -1275,8 +1276,16 @@ async function provideEmmetCompletions(
 
   const isHtml = !isJsDoc(state, document) && isHtmlContext(state, document, position)
   const isJs = isJsDoc(state, document) || isJsxContext(state, document, position)
+  const isEx = isExDoc(state, document) || isExContext(state, document, position)
 
-  const syntax = isHtml ? 'html' : isJs ? 'jsx' : null
+  const syntax = 
+    isHtml ? 
+    'html' : 
+    isJs ? 
+    'jsx' : 
+    isEx ?
+    'ex' :
+    null
 
   if (syntax === null) {
     return null

--- a/packages/tailwindcss-language-service/src/util/css.ts
+++ b/packages/tailwindcss-language-service/src/util/css.ts
@@ -5,6 +5,7 @@ import { isJsDoc } from './js'
 import { State } from './state'
 import { cssLanguages } from './languages'
 import { getLanguageBoundaries } from './getLanguageBoundaries'
+import { isExDoc } from './ex'
 
 export function isCssDoc(state: State, doc: TextDocument): boolean {
   const userCssLanguages = Object.keys(state.editor.userLanguages).filter((lang) =>
@@ -19,7 +20,7 @@ export function isCssContext(state: State, doc: TextDocument, position: Position
     return true
   }
 
-  if (isHtmlDoc(state, doc) || isVueDoc(doc) || isSvelteDoc(doc) || isJsDoc(state, doc)) {
+  if (isHtmlDoc(state, doc) || isVueDoc(doc) || isSvelteDoc(doc) || isJsDoc(state, doc) || isExDoc(state, doc)) {
     let str = doc.getText({
       start: { line: 0, character: 0 },
       end: position,

--- a/packages/tailwindcss-language-service/src/util/ex.ts
+++ b/packages/tailwindcss-language-service/src/util/ex.ts
@@ -1,0 +1,24 @@
+import type { Position } from 'vscode-languageserver'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
+import { State } from './state'
+import { exLanguages } from './languages'
+import { getLanguageBoundaries } from './getLanguageBoundaries'
+
+export function isExDoc(state: State, doc: TextDocument): boolean {
+  const userExLanguages = Object.keys(state.editor.userLanguages).filter((lang) =>
+    exLanguages.includes(state.editor.userLanguages[lang])
+  )
+
+  return [...exLanguages, ...userExLanguages].indexOf(doc.languageId) !== -1
+}
+
+export function isExContext(state: State, doc: TextDocument, position: Position): boolean {
+  let str = doc.getText({
+    start: { line: 0, character: 0 },
+    end: position,
+  })
+
+  let boundaries = getLanguageBoundaries(state, doc, str)
+
+  return boundaries ? ['ex'].includes(boundaries[boundaries.length - 1].type) : false
+}

--- a/packages/tailwindcss-language-service/src/util/languages.ts
+++ b/packages/tailwindcss-language-service/src/util/languages.ts
@@ -56,6 +56,10 @@ export const jsLanguages = [
   'typescriptreact',
 ]
 
+export const exLanguages = [
+  'elixir'
+]
+
 export const specialLanguages = ['vue', 'svelte']
 
 export const languages = [...cssLanguages, ...htmlLanguages, ...jsLanguages, ...specialLanguages]

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -85,7 +85,9 @@
           "source.svelte",
           "source.tsx",
           "source.jsx",
-          "text.html"
+          "source.ex",
+          "text.html",
+          "text.heex"
         ]
       },
       {
@@ -94,7 +96,8 @@
         "injectTo": [
           "source.css.scss",
           "source.tsx",
-          "source.jsx"
+          "source.jsx",
+          "source.ex"
         ]
       },
       {
@@ -103,7 +106,8 @@
         "injectTo": [
           "source.css.postcss",
           "source.tsx",
-          "source.jsx"
+          "source.jsx",
+          "source.ex"
         ]
       },
       {
@@ -116,7 +120,9 @@
           "source.svelte",
           "source.tsx",
           "source.jsx",
-          "text.html"
+          "source.ex",
+          "text.html",
+          "text.heex"
         ]
       },
       {
@@ -129,7 +135,9 @@
           "source.svelte",
           "source.tsx",
           "source.jsx",
-          "text.html"
+          "source.ex",
+          "text.html",
+          "text.heex"
         ]
       },
       {
@@ -142,7 +150,9 @@
           "source.svelte",
           "source.tsx",
           "source.jsx",
-          "text.html"
+          "source.ex",
+          "text.html",
+          "text.heex"
         ]
       }
     ],

--- a/packages/vscode-tailwindcss/package.json
+++ b/packages/vscode-tailwindcss/package.json
@@ -83,6 +83,8 @@
           "source.css",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -90,14 +92,18 @@
         "scopeName": "tailwindcss.at-rules.scss.injection",
         "path": "./syntaxes/at-rules.scss.tmLanguage.json",
         "injectTo": [
-          "source.css.scss"
+          "source.css.scss",
+          "source.tsx",
+          "source.jsx"
         ]
       },
       {
         "scopeName": "tailwindcss.at-rules.postcss.injection",
         "path": "./syntaxes/at-rules.postcss.tmLanguage.json",
         "injectTo": [
-          "source.css.postcss"
+          "source.css.postcss",
+          "source.tsx",
+          "source.jsx"
         ]
       },
       {
@@ -108,6 +114,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -119,6 +127,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       },
@@ -130,6 +140,8 @@
           "source.css.postcss",
           "source.vue",
           "source.svelte",
+          "source.tsx",
+          "source.jsx",
           "text.html"
         ]
       }


### PR DESCRIPTION
As extension of https://github.com/lsegal/tailwindcss-intellisense/tree/styled-jsx
Added support to elixir ~H (heex template inside source) class completion

Before:
![image](https://github.com/gbrlbsls/tailwindcss-intellisense/assets/7686679/dab2cfb6-33e2-4d0f-b851-cf61d3a833cf)

After:
![image](https://github.com/gbrlbsls/tailwindcss-intellisense/assets/7686679/c5732363-4863-47c5-933c-c09d955e8b67)
